### PR TITLE
Integrate AngularJS menu

### DIFF
--- a/src/main/resources/static/js/menu-app.js
+++ b/src/main/resources/static/js/menu-app.js
@@ -1,0 +1,9 @@
+(function () {
+    var app = angular.module('legacyApp', []);
+    app.controller('MenuController', ['$scope', function($scope) {
+        $scope.menuItems = [
+            { name: 'Home', link: '#' },
+            { name: 'About', link: '#about' }
+        ];
+    }]);
+})();

--- a/src/main/resources/templates/reactPage.html
+++ b/src/main/resources/templates/reactPage.html
@@ -1,12 +1,21 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" ng-app="legacyApp">
 <head>
     <meta charset="UTF-8">
-    <title>React App</title>
+    <title>React App with Angular Menu</title>
     <!-- Note: Static resources are served from the classpath root -->
     <link th:href="@{/css/main.css}" rel="stylesheet" />
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.11/angular.min.js"></script>
+    <script th:src="@{/js/menu-app.js}"></script>
 </head>
 <body>
+<div ng-controller="MenuController" class="menu">
+    <ul>
+        <li ng-repeat="item in menuItems">
+            <a ng-href="{{item.link}}">{{item.name}}</a>
+        </li>
+    </ul>
+</div>
 <div id="root"></div>
 <script th:src="@{/js/main.js}"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a basic AngularJS 1.5 menu
- embed the Angular menu alongside the React root

## Testing
- `mvn test` *(fails: `mvn` not found)*