### PR TITLE
Fix Angular menu integration

### DIFF
--- a/frontend/angularjs-app/package.json
+++ b/frontend/angularjs-app/package.json
@@ -6,6 +6,6 @@
     "angular": "1.5.11"
   },
   "scripts": {
-    "build": "mkdir -p dist/js/components && cp src/app.js dist/js && cp src/components/*.js dist/js/components/"
+    "build": "mkdir -p dist/components && cp src/app.js dist && cp src/components/*.js dist/components/"
   }
 }


### PR DESCRIPTION
## Summary
- output AngularJS artifacts to dist/app.js
- ensure Angular menu can be loaded from `/js/angular/app.js`

## Testing
- `mvn test` *(fails: mvn not installed)*