### PR TITLE
Move Angular template and trigger React on menu select

### DIFF
--- a/frontend/angularjs-app/package.json
+++ b/frontend/angularjs-app/package.json
@@ -6,6 +6,6 @@
     "angular": "1.5.11"
   },
   "scripts": {
-    "build": "mkdir -p dist/components && cp src/app.js dist && cp src/components/*.js dist/components/"
+    "build": "mkdir -p dist/components && cp src/app.js dist && cp src/components/*.js dist/components/ && cp src/components/*.html dist/components/"
   }
 }

--- a/frontend/angularjs-app/src/components/menu.component.js
+++ b/frontend/angularjs-app/src/components/menu.component.js
@@ -1,6 +1,15 @@
-angular.module('legacyApp').controller('MenuController', ['$scope', function($scope) {
-  $scope.menuItems = [
-    { name: 'Home', link: '#' },
-    { name: 'About', link: '#about' }
-  ];
-}]);
+angular.module('legacyApp').component('appMenu', {
+  templateUrl: 'js/angular/components/menu.template.html',
+  controller: ['$window', function($window) {
+    this.menuItems = [
+      { name: 'Home' },
+      { name: 'About' }
+    ];
+
+    this.select = function(item) {
+      if ($window.renderReactApp) {
+        $window.renderReactApp();
+      }
+    };
+  }]
+});

--- a/frontend/angularjs-app/src/components/menu.template.html
+++ b/frontend/angularjs-app/src/components/menu.template.html
@@ -1,0 +1,7 @@
+<div class="menu">
+  <ul>
+    <li ng-repeat="item in $ctrl.menuItems">
+      <a href="" ng-click="$ctrl.select(item)">{{item.name}}</a>
+    </li>
+  </ul>
+</div>

--- a/frontend/react-app/src/main.tsx
+++ b/frontend/react-app/src/main.tsx
@@ -3,8 +3,12 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+export function renderReactApp(containerId = 'root') {
+  createRoot(document.getElementById(containerId)!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  )
+}
+
+(window as any).renderReactApp = renderReactApp

--- a/src/main/resources/templates/reactPage.html
+++ b/src/main/resources/templates/reactPage.html
@@ -10,13 +10,7 @@
     <script th:src="@{/js/angular/components/menu.component.js}"></script>
 </head>
 <body>
-<div ng-controller="MenuController" class="menu">
-    <ul>
-        <li ng-repeat="item in menuItems">
-            <a ng-href="{{item.link}}">{{item.name}}</a>
-        </li>
-    </ul>
-</div>
+<app-menu></app-menu>
 <div id="root"></div>
 <script th:src="@{/js/main.js}"></script>
 </body>


### PR DESCRIPTION
## Summary
- move menu markup from the Thymeleaf template to an Angular template file
- convert menu to an Angular component
- expose `renderReactApp` from React and call it when a menu item is clicked
- include Angular HTML templates in build

## Testing
- `npm --version`
- `sh mvnw -q test` *(fails: `cannot open mvnw/.mvn/wrapper/maven-wrapper.properties`)*